### PR TITLE
Update Twitter share URL to use intent/tweet endpoint

### DIFF
--- a/components/TwitterShareButton.tsx
+++ b/components/TwitterShareButton.tsx
@@ -4,7 +4,7 @@ import styles from '@/styles/Article.module.css'
 export function TwitterShareButton({ title }: { title: string }) {
   const shareOnTwitter = () => {
     window.open(
-      `https://twitter.com/share?url=${encodeURIComponent(
+      `https://twitter.com/intent/tweet?url=${encodeURIComponent(
         window.location.href,
       )}&text=${encodeURIComponent(title)}`,
       '',


### PR DESCRIPTION
Twitter のシェアボタンのリンクがAndroidで機能しない問題を修正しました

ref: https://foxism.jp/2023/05/twitter-share-button/